### PR TITLE
Add python support check

### DIFF
--- a/autoload/tern.vim
+++ b/autoload/tern.vim
@@ -1,3 +1,14 @@
+
+if &cp || exists('g:tern_loaded')
+    finish
+endif
+
+if !has('python')
+    echo 'tern requires python support'
+    finish
+endif
+let g:tern_loaded = 1
+
 py << endpy
 
 import vim, os, platform, subprocess, urllib2, webbrowser, json, re, string


### PR DESCRIPTION
Checks if python support is available and outputs a message
if not. Also adds a guard for only loading tern.vim once.
