### PR TITLE
 Adds default mappings for tern commands

### DIFF
--- a/autoload/tern.vim
+++ b/autoload/tern.vim
@@ -416,6 +416,26 @@ function! tern#is_show_argument_hints_enabled()
   return exists('g:tern_show_argument_hints') && g:tern_show_argument_hints
 endfunction
 
+if !exists('g:tern_map_keys')
+    let g:tern_map_keys = 1
+endif
+
+if !exists('g:tern_map_prefix')
+    let g:tern_map_prefix = '<leader>'
+endif
+
+if g:tern_map_keys
+    execute 'autocmd FileType javascript' 'nnoremap <buffer>' g:tern_map_prefix.'td' ':TernDoc<CR>'
+    execute 'autocmd FileType javascript' 'nnoremap <buffer>' g:tern_map_prefix.'tb' ':TernDocBrowse<CR>'
+    execute 'autocmd FileType javascript' 'nnoremap <buffer>' g:tern_map_prefix.'tt' ':TernType<CR>'
+    execute 'autocmd FileType javascript' 'nnoremap <buffer>' g:tern_map_prefix.'td' ':TernDef<CR>'
+    execute 'autocmd FileType javascript' 'nnoremap <buffer>' g:tern_map_prefix.'tpd' ':TernDefPreview<CR>'
+    execute 'autocmd FileType javascript' 'nnoremap <buffer>' g:tern_map_prefix.'tsd' ':TernDefSplit<CR>'
+    execute 'autocmd FileType javascript' 'nnoremap <buffer>' g:tern_map_prefix.'ttd' ':TernDefTab<CR>'
+    execute 'autocmd FileType javascript' 'nnoremap <buffer>' g:tern_map_prefix.'tr' ':TernRefs<CR>'
+    execute 'autocmd FileType javascript' 'nnoremap <buffer>' g:tern_map_prefix.'tR' ':TernRename<CR>'
+endif
+
 function! tern#Enable()
   if stridx(&buftype, "nofile") > -1 || stridx(&buftype, "nowrite") > -1
     return


### PR DESCRIPTION
Adds default mappings for tern commands which
can be configured via g:tern_map_keys and tern_map_prefix
for enabling/disabling the default mappings and selecting the
leader character for the default mappings respectively.
