### PR TITLE
Set .tern-project filetype to json

### DIFF
--- a/ftdetect/tern.vim
+++ b/ftdetect/tern.vim
@@ -1,0 +1,1 @@
+au BufNewFile,BufRead .tern-project setf json


### PR DESCRIPTION
Sets the filetype of the tern project configuration file to json using an autocmd. It's nice to let vim know that it's actually json so you also get proper indentation and syntax validation (when using syntastic or similar ..)
