### PR TITLE
Fix URLs to Pathogen, Node, npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,6 @@ Tern uses `.tern-project` files to configure loading libraries and
 plugins for a project. See the [Tern docs][docs] for details.
 
 [docs]: http://ternjs.net/doc/manual.html#configuration
+[path]: https://github.com/tpope/vim-pathogen
+[node]: http://nodejs.org/
+[npm]: https://npmjs.org/


### PR DESCRIPTION
Added the URLs for the links to Pathogen / Node / npm.
