### PR TITLE
Add stdin to subprocess call

### DIFF
--- a/autoload/tern.vim
+++ b/autoload/tern.vim
@@ -84,7 +84,8 @@ def tern_startServer(project):
     env["PATH"] += ":/usr/local/bin"
   proc = subprocess.Popen(vim.eval("g:tern#command") + vim.eval("g:tern#arguments"),
                           cwd=project.dir, env=env,
-                          stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=win)
+                          stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                          stderr=subprocess.STDOUT, shell=win)
   output = ""
   while True:
     line = proc.stdout.readline()


### PR DESCRIPTION
On windows I've been seeing errors when using tern omnicomplete. The error is in the tern_startServer function, and the bottom of the stack track looks like this (sorry, I'm not able to capture the full stack trace at the minute, but it's definitely the subprocess.Popen call in tern_startServer where it's happening):

```
File "C:\dev\cpython\cpython\lib\subprocess.py", line 732, in __init__
  errread, errwrite) = self._get_handles(stdin, stdout, stderr)
File "C:\dev\cpython\cpython\lib\subprocess.py", line 903, in _get_handles
  p2cread = self._make_inheritable(p2cread)
File "C:\dev\cpython\cpython\lib\subprocess.py", line 946, in _make_inheritable
  _subprocess.DUPLICATE_SAME_ACCESS)
WindowsError: [Error 6] The handle is invalid
```

Googling for the error I've found several other projects that give the same underlying windows error, such as one here: http://bugs.python.org/issue3905  (I am using python 2.7.5, so this doesnt seem to be a 'legacy python' issue even though the thread in the link is from 2011).

The suggested fix on there is to add the named stdin parameter to the Popen call, which I've done and this seems to fix the problem - tern seems to work correctly with the patch applied.
