### PR TITLE
rely on tern soft exiting when its stdin ends

### DIFF
--- a/autoload/tern.vim
+++ b/autoload/tern.vim
@@ -105,9 +105,7 @@ def tern_startServer(project):
 def tern_killServer(project):
   if project.proc is None: return
   try:
-    if platform.system() == "Windows":
-      subprocess.call("taskkill /t /f /pid " + str(project.proc.pid), shell=True)
-    else:
+    if platform.system() != "Windows":
       project.proc.terminate()
       project.proc.wait()
   except:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tern_for_vim",
   "license": "MIT",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": "Marijn Haverbeke <marijnh@gmail.com>",
   "description": "Sublime Text package for Vim",
   "repository": {
@@ -9,6 +9,6 @@
     "url": "git://github.com/marijnh/tern_for_vim.git"
   },
   "dependencies": {
-    "tern": ">=0.2"
+    "tern": ">=0.4.2"
   }
 }


### PR DESCRIPTION
avoid use of taskkill (which prevents cleanup of .tern-port) on windows

NOTES:
- depends on matching pull request for tern, "soft exit when stdin ends"
- this method should work on non-windows, too, so you might be able to remove the platform check, but I can't test that
