### PR TITLE
Use file on disk if the buffer isn't modified.

### DIFF
--- a/script/tern.py
+++ b/script/tern.py
@@ -189,6 +189,13 @@ def tern_runCommand(query, pos=None, fragments=True, silent=False):
   doc = {"query": query, "files": []}
   if curSeq == vim.eval("b:ternBufferSentAt"):
     fname, sendingFile = (tern_relativeFile(), False)
+  elif not int(vim.eval('&modified')):
+    fname, sendingFile = (tern_relativeFile(), False)
+    doc["files"].append({
+      "type": "delete",
+      "name": fname
+    })
+    vim.command("let b:ternBufferSentAt = " + str(curSeq))
   elif len(vim.current.buffer) > 250 and fragments:
     f = tern_bufferFragment()
     doc["files"].append(f)


### PR DESCRIPTION
A quick fix for enabling `TernDoc`, etc. to work on long files.

The `ternBufferSentAt` is modified so that the `delete` isn't hit repeatedly in case multiple requests are invoked for the same unmodified file.