### PR TITLE
Fix map conflict and update documentation

### DIFF
--- a/autoload/tern.vim
+++ b/autoload/tern.vim
@@ -117,7 +117,7 @@ endif
 
 function! tern#DefaultKeyMap(...)
   let prefix = len(a:000)==1 ? a:1 : "<LocalLeader>"
-  execute 'nnoremap <buffer> '.prefix.'td' ':TernDoc<CR>'
+  execute 'nnoremap <buffer> '.prefix.'tD' ':TernDoc<CR>'
   execute 'nnoremap <buffer> '.prefix.'tb' ':TernDocBrowse<CR>'
   execute 'nnoremap <buffer> '.prefix.'tt' ':TernType<CR>'
   execute 'nnoremap <buffer> '.prefix.'td' ':TernDef<CR>'

--- a/doc/tern.txt
+++ b/doc/tern.txt
@@ -118,8 +118,33 @@ OPTIONS                                                           *tern-options*
 
 The following options are available:
 
+    |tern_map_keys|.................. Enable or disable default key mappings.
+    |tern_map_prefix|................ Configure mapping prefix.
     |tern_show_argument_hints|....... Configure argument hints display.
     |tern_show_signature_in_pum|..... Configure completion menu display.
+
+-------------------------------------------------------------------------------
+                                                                 *tern_map_keys*
+
+Defaults to 0. Can be set to 1 to enable the following key mappings. By default
+these mappings are prefixed with |<LocalLeader>|. You can change this prefix
+with |tern_map_prefix| option.
+
+    *<LocalLeader>tD*   |TernDoc|
+    *<LocalLeader>tb*   |TernDocBrowse|
+    *<LocalLeader>tt*   |TernType|
+    *<LocalLeader>td*   |TernDef|
+    *<LocalLeader>tpd*  |TernDefPreview|
+    *<LocalLeader>tsd*  |TernDefSplit|
+    *<LocalLeader>ttd*  |TernDefTab|
+    *<LocalLeader>tr*   |TernRefs|
+    *<LocalLeader>tR*   |TernRename|
+
+-------------------------------------------------------------------------------
+                                                               *tern_map_prefix*
+
+Defaults to |<LocalLeader>|. Specifies prefix which is used to define default
+key mappings.
 
 -------------------------------------------------------------------------------
                                                       *tern_show_argument_hints*

--- a/doc/tern.txt
+++ b/doc/tern.txt
@@ -19,7 +19,7 @@ intelligent renaming.
 ==============================================================================
 INSTALLATION                                                      *tern-install*
 
-Install the plugin using your prefered plugin manager or copy the files
+Install the plugin using your preferred plugin manager or copy the files
 to your ~/.vim directory manually. Make sure you have npm and node installed
 and run the following from the root path of the plugin (the same directory
 in which the file package.json is located): >

--- a/doc/tern.txt
+++ b/doc/tern.txt
@@ -34,7 +34,7 @@ USAGE                                                               *tern-usage*
 
 After installation vim will use the tern supplied omnifunc to handle
 omnicomplete calls for javascript files. In order to set up tern for
-use with your project you should create a '.tern-project' file in the root
+use with your project you should create a ".tern-project" file in the root
 directory of your project. The following is just an example:
 >
     {
@@ -55,7 +55,7 @@ directory of your project. The following is just an example:
 >
 
 This will tell the tern server to load definitions for jquery and the
-browser environment. Furthermore it will parse 'importantfile.js' on start up
+browser environment. Furthermore it will parse "importantfile.js" on start up
 and register the requirejs plugin.
 
 For more detailed description of this configuration please refer to the online
@@ -66,51 +66,51 @@ COMMANDS                                                         *tern-commands*
 
 The following commands are available:
 
-    |TernDoc|....................... Look up Documentation
-    |TernDocBrowse|................. Browse the Documentation
-    |TernType|...................... Perform a type look up
-    |TernDef|....................... Look up definition
-    |TernDefPreview|................ Look up definition in preview
-    |TernDefSplit|.................. Look up definition in new split
-    |TernDefTab|.................... Look up definition in new tab
-    |TernRefs|...................... Look up references
-    |TernRename|.................... Rename identifier
+    |:TernDoc|...................... Look up Documentation
+    |:TernDocBrowse|................ Browse the Documentation
+    |:TernType|..................... Perform a type look up
+    |:TernDef|...................... Look up definition
+    |:TernDefPreview|............... Look up definition in preview
+    |:TernDefSplit|................. Look up definition in new split
+    |:TernDefTab|................... Look up definition in new tab
+    |:TernRefs|..................... Look up references
+    |:TernRename|................... Rename identifier
 
 ------------------------------------------------------------------------------
-                                                                       *TernDoc*
+                                                                      *:TernDoc*
 Look up the documentation of something.
 
 ------------------------------------------------------------------------------
-                                                                 *TernDocBrowse*
+                                                                *:TernDocBrowse*
 Open the documentation in an external browser.
 
 ------------------------------------------------------------------------------
-                                                                      *TernType*
+                                                                     *:TernType*
 Find the type of the identifier under the cursor.
 
 ------------------------------------------------------------------------------
-                                                                       *TernDef*
+                                                                      *:TernDef*
 Jump to the definition of the identifier under the cursor.
 
 ------------------------------------------------------------------------------
-                                                                *TernDefPreview*
+                                                               *:TernDefPreview*
 Jump to the definition of the identifier under the cursor inside
 the preview window.
 
 ------------------------------------------------------------------------------
-                                                                  *TernDefSplit*
+                                                                 *:TernDefSplit*
 Jump to the definition of the identifier under the cursor in a new split.
 
 ------------------------------------------------------------------------------
-                                                                    *TernDefTab*
+                                                                   *:TernDefTab*
 Jump to the definition of the identifier under the cursor in a new tab.
 
 ------------------------------------------------------------------------------
-                                                                      *TernRefs*
+                                                                     *:TernRefs*
 List all references of the identifier under the cursor.
 
 ------------------------------------------------------------------------------
-                                                                    *TernRename*
+                                                                   *:TernRename*
 Rename the variable under the cursor.
 
 ==============================================================================
@@ -130,15 +130,15 @@ Defaults to 0. Can be set to 1 to enable the following key mappings. By default
 these mappings are prefixed with |<LocalLeader>|. You can change this prefix
 with |tern_map_prefix| option.
 
-    *<LocalLeader>tD*   |TernDoc|
-    *<LocalLeader>tb*   |TernDocBrowse|
-    *<LocalLeader>tt*   |TernType|
-    *<LocalLeader>td*   |TernDef|
-    *<LocalLeader>tpd*  |TernDefPreview|
-    *<LocalLeader>tsd*  |TernDefSplit|
-    *<LocalLeader>ttd*  |TernDefTab|
-    *<LocalLeader>tr*   |TernRefs|
-    *<LocalLeader>tR*   |TernRename|
+    *<LocalLeader>tD*   |:TernDoc|
+    *<LocalLeader>tb*   |:TernDocBrowse|
+    *<LocalLeader>tt*   |:TernType|
+    *<LocalLeader>td*   |:TernDef|
+    *<LocalLeader>tpd*  |:TernDefPreview|
+    *<LocalLeader>tsd*  |:TernDefSplit|
+    *<LocalLeader>ttd*  |:TernDefTab|
+    *<LocalLeader>tr*   |:TernRefs|
+    *<LocalLeader>tR*   |:TernRename|
 
 -------------------------------------------------------------------------------
                                                                *tern_map_prefix*
@@ -149,16 +149,16 @@ key mappings.
 -------------------------------------------------------------------------------
                                                       *tern_show_argument_hints*
 
-Defaults to |'no'|. Can be set to |'on_move'| to update the argument
-hints whenever the cursor moves, or |'on_hold'| to do it whenever the
-cursor is held still for a period that depends on the |updatetime|
-setting. |'on_move'| can reduce responsiveness on slow systems or big
-codebases. |'on_hold'| probably requires you to set |updatetime| to
+Defaults to "no". Can be set to "on_move" to update the argument
+hints whenever the cursor moves, or "on_hold" to do it whenever the
+cursor is held still for a period that depends on the 'updatetime'
+setting. "on_move" can reduce responsiveness on slow systems or big
+codebases. "on_hold" probably requires you to set 'updatetime' to
 something smaller than the default of 4 seconds.
 
 If you do not see argument hints while in insert mode you might
 have to disable the mode indication (:set noshowmode). For more
-information see |'noshowmode'|.
+information see 'noshowmode'.
 
 -------------------------------------------------------------------------------
                                                     *tern_show_signature_in_pum*


### PR DESCRIPTION
These changes fix conflict between `:TernDef` and `:TernDoc` mappings and add documentation on default mappings.