### PR TITLE
FIX: Failing on Python3 < 3.3, due to using unicode literal prefix

### DIFF
--- a/script/tern.py
+++ b/script/tern.py
@@ -293,7 +293,7 @@ def tern_lookupDocumentation(browse=False):
   doc = data.get("doc")
   url = data.get("url")
   if url:
-    if browse: 
+    if browse:
       savout = os.dup(1)
       os.close(1)
       os.open(os.devnull, os.O_RDWR)
@@ -342,7 +342,7 @@ def tern_lookupDefinition(cmd):
       vim.command("call cursor(" + str(lnum) + "," + str(col) + ")")
     else:
       vim.command(cmd + " +call\ cursor(" + str(lnum) + "," + str(col) + ") " +
-        tern_projectFilePath(filename).replace(u" ", u"\\ "))
+        tern_projectFilePath(filename).replace(" ", "\\ "))
   elif "url" in data:
     print("see " + data["url"])
   else:


### PR DESCRIPTION
When using tern_for_vim with python < 3.3 this script will fail and throw errors when loading .js files. 
A common reason is using gvim74 on windows. Many users are required to use an older python version like 3.2 in order to get gvim python enabled. 

Python < 3.3 doesnt support https://www.python.org/dev/peps/pep-0414/ hence the 'u' prefix will fail. Since this prefix isn't used in other parts of tern.py, I assume it is save to be removed? 

See http://stackoverflow.com/questions/23691408/install-gvim-on-windows-with-python3-support
for some more explantion