### PR TITLE
Modified as ternBufferSentAt is set only once

### DIFF
--- a/autoload/tern.vim
+++ b/autoload/tern.vim
@@ -139,7 +139,9 @@ function! tern#Enable()
   let b:ternProjectDir = ''
   let b:ternLastCompletion = []
   let b:ternLastCompletionPos = {'row': -1, 'start': 0, 'end': 0}
-  let b:ternBufferSentAt = undotree()['seq_cur']
+  if !exists('b:ternBufferSentAt')
+    let b:ternBufferSentAt = undotree()['seq_cur']
+  endif
   let b:ternInsertActive = 0
   if g:tern_set_omni_function
     setlocal omnifunc=tern#Complete


### PR DESCRIPTION
With the NeoBundle's lazy loading, ftplugin is loaded more than once. In this case, the ternBufferSentAt is re-setting, not the contents of the file is sent, it does not operate normally (first time only).

### Steps to Reproduce

1. Open JavaScript file (following such content)
2. Type `o` (enter insert-mode)
  - undotree().seq_cur is increased
  - NeoBundle reload the plugin in this timing
  - b:ternBufferSentAt is re-set to current undotree().seq_cur
3. Type `a.`
  - curSeq equals vim.eval("b:ternBufferSentAt")
4. It is expected to be complemented (a.`foo [O]`), but an error occurs (`TernError: Position 26 is outside of file.`)

```js
var a = { foo: "bar" };
a.
```
