### PR TITLE
Add option for showing the loc after renaming

### DIFF
--- a/autoload/tern.vim
+++ b/autoload/tern.vim
@@ -97,6 +97,10 @@ if !exists('g:tern_request_timeout')
   let g:tern_request_timeout = 1
 endif
 
+if !exists('g:tern_show_loc_after_rename')
+  let g:tern_show_loc_after_rename = 1
+endif
+
 function! tern#DefaultKeyMap(...)
   let prefix = len(a:000)==1 ? a:1 : "<LocalLeader>"
   execute 'nnoremap <buffer> '.prefix.'tD' ':TernDoc<CR>'

--- a/doc/tern.txt
+++ b/doc/tern.txt
@@ -166,3 +166,9 @@ information see 'noshowmode'.
 Defaults to 0. Can be set to 1 to display function signatures in the completion
 menu. Function signatures include parameter names, their type, and whether the
 parameter is optional.
+
+-------------------------------------------------------------------------------
+                                                    *tern_show_loc_after_rename*
+
+Defaults to 1. Can be set to 0 to avoid showing the location list after
+renaming an identifier.

--- a/script/tern.py
+++ b/script/tern.py
@@ -443,4 +443,6 @@ def tern_rename(newName):
       external.append({"name": file, "text": "".join(lines), "type": "full"})
   if len(external):
     tern_sendBuffer(external)
-  vim.command("call setloclist(0," + json.dumps(changes) + ") | lopen")
+
+  if vim.eval("g:tern_show_loc_after_rename") == '1':
+    vim.command("call setloclist(0," + json.dumps(changes) + ") | lopen")


### PR DESCRIPTION
This PR adds an option `g:tern_show_loc_after_rename`. This allows to configure if the location list is shown when you do a TernRename.

Fixes #151.