### PR TITLE
Multiple TernDef calls from within script: jumplist

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "url": "git://github.com/ternjs/tern_for_vim.git"
   },
   "dependencies": {
-    "tern": ">=0.5"
+    "tern": ">=0.5",
+    "tern-jsx": "^1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "url": "git://github.com/ternjs/tern_for_vim.git"
   },
   "dependencies": {
+    "acorn": "^5.3.0",
     "tern": ">=0.5",
     "tern-jsx": "^1.0.2"
   }

--- a/script/tern.py
+++ b/script/tern.py
@@ -334,7 +334,7 @@ def tern_lookupArgumentHints(fname, apos):
                          True, True)
   if data: tern_echoWrap(data.get("type", ""),name=fname)
 
-def tern_lookupDefinition(cmd):
+def tern_lookupDefinition(cmd, add_jump_position=True):
   data = tern_runCommand("definition", fragments=False)
   if data is None: return
 
@@ -344,7 +344,8 @@ def tern_lookupDefinition(cmd):
     filename = data["file"]
 
     if cmd == "edit" and filename == tern_relativeFile():
-      vim.command("normal! m`")
+      if add_jump_position:
+        vim.command("normal! m`")
       vim.command("call cursor(" + str(lnum) + "," + str(col) + ")")
     else:
       vim.command(cmd + " +call\ cursor(" + str(lnum) + "," + str(col) + ") " +

--- a/script/tern.py
+++ b/script/tern.py
@@ -31,6 +31,10 @@ def tern_makeRequest(port, doc, silent=False):
     localhost = 'localhost'
     if platform.system().lower()=='windows':
         localhost = '127.0.0.1'
+    # file=open("/tmp/ternrequest", "w")
+    # file.write(json.dumps(doc))
+    # file.close()
+
     req = opener.open("http://" + localhost + ":" + str(port) + "/", payload,
                       float(vim.eval("g:tern_request_timeout")))
     result = req.read()

--- a/script/tern.py
+++ b/script/tern.py
@@ -375,6 +375,23 @@ def tern_refs():
                  "text": name + " (file not loaded)" if len(text)==0 else text[0]})
   vim.command("call setloclist(0," + json.dumps(refs) + ") | lopen")
 
+
+def tern_refs2():
+  data = tern_runCommand("refs", fragments=False)
+  refs = []
+  if data is not None:
+    for ref in data["refs"]:
+      lnum     = ref["start"]["line"] + 1
+      col      = ref["start"]["ch"] + 1
+      filename = tern_projectFilePath(ref["file"])
+      name     = data["name"]
+      text     = vim.eval("getbufline('" + filename + "'," + str(lnum) + ")")
+      refs.append({"lnum": lnum,
+                  "col": col,
+                  "filename": filename,
+                  "text": name + " (file not loaded)" if len(text)==0 else text[0]})
+  vim.command("call DefaultTernHandler(" + json.dumps(refs) + ")")
+
 # Copied here because Python 2.6 and lower don't have it built in, and
 # python 3.0 and higher don't support old-style cmp= args to the sort
 # method. There's probably a better way to do this...


### PR DESCRIPTION
   we are using requirejs and many times tern jumps into the `return` of the function ( which is correct since this is  where the variable was defined ) but we want to further jump and get to the initial definition of what we were  looking for. I've added a piece of code that does just that, based on our codestyle a simple regex may inform us that  this is not the place we wanted to see... but we are getting additional stop on our way back with ctrl+o. we would  like to ask tern for additional jumps without adding to the jump list.
following the piece of code in my .vimrc ( still need improvement but it's good enough for now )
```vim
function! GoToDeclaration()
    let l:pos = getpos('.')
    let l:currFileName = expand('%')
    let l:lineFromCursorPosition = strpart(getline('.'), getpos('.')[2])
    let l:wordUnderCursor = expand('<cword>')
    let l:isFunction = match(l:lineFromCursorPosition , '^\(\w\|\s\)*(') + 1
    silent TernDef
    if join(l:pos) == join(getpos('.'))
        "can't jump to definition with tern, do a search with ag + fzf
        if l:isFunction
            FindNoTestFunction(l:wordUnderCursor)
        else
            call fzf#vim#ag(expand('<cword>'), s:defaultPreview ) 
        endif
        call feedkeys(l:wordUnderCursor)
    else
        let l:newCursorLine = getline('.')
        let l:newCurrFileName = expand('%')
        let l:regex = '^\s*' . l:wordUnderCursor . '\s*\(,\?\|\(:\s*' . l:wordUnderCursor . ',\?\)\)\s*$'
        echom l:regex
        if l:newCurrFileName != l:currFileName && match(l:newCursorLine, '\((\|=\)') < 0 && match(getline('.'), regex ) + 1
            "we are inside a module.exports, maybe we can get to the line where the function is declared
            echom 'the line: ' . getline('.')
            call search(l:wordUnderCursor . '\s*\((\|=\)')
            " note that i changed this function in python to allow `add_jump_position` argument
            py3 tern_lookupDefinition("edit", add_jump_position=False)
        endif
        normal zz
        call CursorPing()
    endif
endfunction
``` 
