### PR TITLE
add g:tern_request_query option

### DIFF
--- a/autoload/tern.vim
+++ b/autoload/tern.vim
@@ -97,6 +97,10 @@ if !exists('g:tern_request_timeout')
   let g:tern_request_timeout = 1
 endif
 
+if !exists('g:tern_request_query')
+  let g:tern_request_query = {}
+endif
+
 if !exists('g:tern_show_loc_after_rename')
   let g:tern_show_loc_after_rename = 1
 endif

--- a/script/tern.py
+++ b/script/tern.py
@@ -267,8 +267,15 @@ def tern_ensureCompletionCached():
       (not re.match(".*\\W", curLine[int(cached["end"]):curCol]))):
     return
 
-  data = tern_runCommand({"type": "completions", "types": True, "docs": True},
-                         {"line": curRow - 1, "ch": curCol})
+  ternRequestQuery = vim.eval('g:tern_request_query')
+  ternCompletionQuery = ternRequestQuery.get('completions')
+
+  if ternCompletionQuery is None:
+    ternCompletionQuery = dict()
+
+  completionQuery = dict({"type": "completions", "types": True, "docs": True}, **ternCompletionQuery)
+
+  data = tern_runCommand(completionQuery, {"line": curRow - 1, "ch": curCol})
   if data is None: return
 
   completions = []


### PR DESCRIPTION
`tern_for_vim` now seems not support `includeKeywords` options, etc 
here i add `g:tern_request_query` option.

example:

```vim
let g:tern_request_query = {
  \ 'completions': {
      \ 'includeKeywords': v:true
  \ }
\ }
```
now i can complete keywords like `import`, `export`, `function`, etc.