### PR TITLE
print doc to status bar instead of spliting a window if length <= 120

### DIFF
--- a/script/tern.py
+++ b/script/tern.py
@@ -319,7 +319,7 @@ def tern_lookupDocumentation(browse=False):
         return result
     doc = ((doc and doc + "\n\n") or "") + "See " + url
   if doc:
-    docstr = json.dumps(doc)
+    docstr = json.dumps(doc, ensure_ascii=False)
     if len(docstr) > 120:
       vim.command("call tern#PreviewInfo(" + docstr + ")")
     else:

--- a/script/tern.py
+++ b/script/tern.py
@@ -319,7 +319,11 @@ def tern_lookupDocumentation(browse=False):
         return result
     doc = ((doc and doc + "\n\n") or "") + "See " + url
   if doc:
-    vim.command("call tern#PreviewInfo(" + json.dumps(doc) + ")")
+    docstr = json.dumps(doc)
+    if len(docstr) > 120:
+      vim.command("call tern#PreviewInfo(" + docstr + ")")
+    else:
+      print(docstr)
   else:
     print("no documentation found")
 


### PR DESCRIPTION
I think it's a better way to show doc on status bar if length of doc is small, because this is a silent way and doc can display well too.

And fix non ascii chars showing escaped string instead of showing as it is.