### PR TITLE
keep splitting doc window at bottom

### DIFF
--- a/autoload/tern.vim
+++ b/autoload/tern.vim
@@ -21,10 +21,15 @@ endif
 
 function! tern#PreviewInfo(info)
   pclose
+  let s:originalSplitBelow = &splitbelow
+  set splitbelow
   new +setlocal\ previewwindow|setlocal\ buftype=nofile|setlocal\ noswapfile|setlocal\ wrap
   exe "normal z" . &previewheight . "\<cr>"
   call append(0, type(a:info)==type("") ? split(a:info, "\n") : a:info)
   wincmd p
+  if (s:originalSplitBelow != 1)
+      set nosplitbelow
+  endif
 endfunction
 
 function! tern#Complete(findstart, complWord)

--- a/script/tern.py
+++ b/script/tern.py
@@ -319,7 +319,7 @@ def tern_lookupDocumentation(browse=False):
         return result
     doc = ((doc and doc + "\n\n") or "") + "See " + url
   if doc:
-    docstr = json.dumps(doc)
+    docstr = json.dumps(doc, ensure_ascii=False)
     if len(docstr) > 120:
       vim.command("call tern#PreviewInfo(" + docstr + ")")
     else:

--- a/script/tern.py
+++ b/script/tern.py
@@ -319,7 +319,11 @@ def tern_lookupDocumentation(browse=False):
         return result
     doc = ((doc and doc + "\n\n") or "") + "See " + url
   if doc:
-    vim.command("call tern#PreviewInfo(" + json.dumps(doc) + ")")
+    docstr = json.dumps(doc)
+    if len(docstr) > 120:
+      vim.command("call tern#PreviewInfo(" + docstr + ")")
+    else:
+      print(docstr)
   else:
     print("no documentation found")
 


### PR DESCRIPTION
According to this suggestion, I split doc window at bottom while keeping user's split setting of `splitbelow`.