### PR TITLE
Check if file is changed after :TernRename

### DIFF
--- a/script/tern.py
+++ b/script/tern.py
@@ -465,7 +465,7 @@ def tern_rename(newName):
   if len(external):
     tern_sendBuffer(external)
 
-  vim.command("call setloclist(0," + json.dumps(changes) + ")")
+  vim.command("checktime | call setloclist(0," + json.dumps(changes) + ")")
   if vim.eval("g:tern_show_loc_after_rename") == '1':
     vim.command("lopen")
   else:


### PR DESCRIPTION
For some reason Vim on Windows sometimes doesn't register
changes made with ':TernRename'. ':checktime' will force it
to check if buffers were changed outside of Vim.