### PR TITLE
Fix :TernRename on Windows

### DIFF
--- a/script/tern.py
+++ b/script/tern.py
@@ -433,6 +433,8 @@ def tern_rename(newName):
     for buf in vim.buffers:
       if buf.name == file:
         buffer = buf
+      if platform.system().lower()=='windows' and buf.name == file.replace('/', '\\'):
+        buffer = buf
 
     if buffer is not None:
       lines = buffer
@@ -465,7 +467,7 @@ def tern_rename(newName):
   if len(external):
     tern_sendBuffer(external)
 
-  vim.command("checktime | call setloclist(0," + json.dumps(changes) + ")")
+  vim.command("call setloclist(0," + json.dumps(changes) + ")")
   if vim.eval("g:tern_show_loc_after_rename") == '1':
     vim.command("lopen")
   else:


### PR DESCRIPTION
Vim on Windows uses backslash as path separators but Tern produces
path containing forward slash. Replace forward slashes with
backslashes when on Windows. This makes ':checktime' unnecessary
because only buffer is modified.