### PR TITLE
Fix unkown func when open js file

### DIFF
--- a/after/ftplugin/javascript_tern.vim
+++ b/after/ftplugin/javascript_tern.vim
@@ -1,3 +1,8 @@
+if !has('python') && !has('python3')
+  echo 'tern requires python support'
+  finish
+endif
+
 call tern#Enable()
 
 " Menu 


### PR DESCRIPTION
When using vim without +py or +py3, we will get error like `unknow func tern#enable()`

I think this should be disabled, and just echo an message tell the user tern need python support.