### PR TITLE
Reset autocmd for .tern-project, .tern-config ftdetect

### DIFF
--- a/ftdetect/tern.vim
+++ b/ftdetect/tern.vim
@@ -1,2 +1,5 @@
-au BufNewFile,BufRead .tern-project setf json
-au BufNewFile,BufRead .tern-config setf json
+augroup TernFtdetect
+  autocmd!
+  autocmd BufNewFile,BufRead .tern-project setfiletype json
+  autocmd BufNewFile,BufRead .tern-config setfiletype json
+augroup END


### PR DESCRIPTION
Avoid defining multiple autocmds when reloading `.vimrc`